### PR TITLE
mtk: init: don't crash if no preloader was supplied

### DIFF
--- a/mtk
+++ b/mtk
@@ -119,7 +119,10 @@ class Mtk(metaclass=LogBase):
             pid = self.pid
         if interface is None:
             interface = self.interface
-        preloader = self.args.preloader
+        try:
+            preloader = self.args.preloader
+        except AttributeError:
+            preloader = None
         if vid != -1 and pid != -1:
             if interface == -1:
                 for dev in default_ids:


### PR DESCRIPTION
* Commit https://github.com/bkerler/mtkclient/commit/bef2d8efd0750c111904a437ef571b081deb09fd seems to break the init
  function when no preloader is provided at all (using the --preloader option).