### PR TITLE
partitionname is not expected in writeflash removed

### DIFF
--- a/mtk
+++ b/mtk
@@ -1050,7 +1050,7 @@ class Main(metaclass=LogBase):
                     if mtk.daloader.writeflash(addr=pos,
                                                length=size,
                                                filename=partfilename,
-                                               partitionname=None, parttype=parttype):
+                                               parttype=parttype):
                         print(f"Wrote {partfilename} to sector {str(pos // 0x200)} with " +
                               f"sector count {str(size // 0x200)}.")
                     else:


### PR DESCRIPTION
I got an exception when I tried to write whole flash and none method writeflash expect the parameter partitionname so I removed it and write whole flash start.
