### PR TITLE
Set Correct name for mt6781

### DIFF
--- a/mtkclient/config/brom_config.py
+++ b/mtkclient/config/brom_config.py
@@ -852,7 +852,7 @@ hwconfig = {
         damode=damodes.XFLASH,
         dacode=0x6781,
         name="MT6781",
-        description="Helio A22",
+        description="Helio G96",
         loader="mt6781_payload.bin"
     ),
     0x813: chipconfig(var1=0xA,  # confirmed


### PR DESCRIPTION
MT6781 is Helio G96 while MT6761 is Helio A22