### PR TITLE
Fixes and improvements for mt6575, mt6577. New generic write function. setreg_disablewatchdog optimization.

### DIFF
--- a/mtkclient/config/brom_config.py
+++ b/mtkclient/config/brom_config.py
@@ -305,7 +305,7 @@ hwconfig = {
         dacode=0x6573,
         name="MT6573/MT6260"),
     0x6575: chipconfig(  # var1
-        watchdog=0xC0000000,  #
+        watchdog=0xC0000000,
         uart=0xC1009000,
         da_payload_addr=0xc2001000,
         pl_payload_addr=0xc2058000,
@@ -315,11 +315,11 @@ hwconfig = {
         # cqdma_base
         ap_dma_mem=0xC100119C,
         # blacklist
-        damode=damodes.DEFAULT,  #
+        damode=damodes.DEFAULT,
         dacode=0x6575,
         name="MT6575/77"),
     0x6577: chipconfig(  # var1
-        watchdog=0xC0000000,  # fixme
+        watchdog=0xC0000000,
         uart=0xC1009000,
         da_payload_addr=0xc2001000,
         pl_payload_addr=0xc2058000,
@@ -329,7 +329,7 @@ hwconfig = {
         # cqdma_base
         ap_dma_mem=0xC100119C,
         # blacklist
-        damode=damodes.DEFAULT,  #
+        damode=damodes.DEFAULT,
         dacode=0x6577,
         name="MT6577"),
     0x6580: chipconfig(var1=0xAC,

--- a/mtkclient/config/brom_config.py
+++ b/mtkclient/config/brom_config.py
@@ -306,7 +306,7 @@ hwconfig = {
         name="MT6573/MT6260"),
     0x6575: chipconfig(  # var1
         watchdog=0xC0000000,  #
-        # uart
+        uart=0xC1009000,
         da_payload_addr=0xc2001000,
         pl_payload_addr=0xc2058000,
         # gcpu_base

--- a/mtkclient/config/mtk_config.py
+++ b/mtkclient/config/mtk_config.py
@@ -171,7 +171,7 @@ class Mtk_Config(metaclass=LogBase):
             elif wdt == 0x10007400:
                 return [wdt, 0x22000000]
             elif wdt == 0xC0000000:
-                return [wdt, 0x0]
+                return [wdt, 0x2264]
             elif wdt == 0x2200:
                 if self.hwcode == 0x6276 or self.hwcode == 0x8163:
                     return [wdt, 0x610C0000]


### PR DESCRIPTION
When I tried running mtkclient with my device I've got the following log:
```
MTK Flash/Exploit Client V1.55 (c) B.Kerler 2018-2022

Preloader - Status: Waiting for PreLoader VCOM, please connect mobile
Preloader
Preloader - [LIB]: Status: Handshake failed, retrying...
Preloader
Preloader - [LIB]: Status: Handshake failed, retrying...
Port - Device detected :)
Preloader - 	CPU:			MT6575/77()
Preloader - 	HW version:		0x0
Preloader - 	WDT:			0xc0000000
Preloader - 	Uart:			0x11002000
Preloader - 	Brom payload addr:	0x100a00
Preloader - 	DA payload addr:	0xc2001000
Preloader - 	Var1:			0xa
Preloader - Disabling Watchdog...
usb_class - USBError(32, 'Pipe error')
Traceback (most recent call last):
  File "/mnt/hdd/soft/mtkclient/mtk", line 698, in <module>
    mtk = Main(args).run()
  File "/mnt/hdd/soft/mtkclient/mtkclient/Library/mtk_main.py", line 338, in run
    if mtk.preloader.init():
  File "/mnt/hdd/soft/mtkclient/mtkclient/Library/mtk_preloader.py", line 192, in init
    self.setreg_disablewatchdogtimer(self.config.hwcode)  # D4
  File "/mnt/hdd/soft/mtkclient/mtkclient/Library/mtk_preloader.py", line 361, in setreg_disablewatchdogtimer
    res = self.write32(0x2200, [0xC0000000])
  File "/mnt/hdd/soft/mtkclient/mtkclient/Library/mtk_preloader.py", line 247, in write32
    if status > 0xFF:
TypeError: '>' not supported between instances of 'list' and 'int'
```

I decided to dig into the code myself. Long story short, after implementing a quick dirty hack I though about polishing it and making several more improvements here and there.

The commits from this PR were tested on Re Live DVD with the following devices:

1. mt6753: **still works**; the new code doesn't introduce code regressions.
2. mt8317 (hwcode is 0x6575 but physically it's close to 6577): **works now**; watchdog can now be disabled.
3. mt8389 (hwcode is 0x6583 but physically it's close to 6589): still works; I tested it just to verify lack of code regression for a very old device.