### PR TITLE
Fix GUI Launching

### DIFF
--- a/mtkclient/Library/Connection/devicehandler.py
+++ b/mtkclient/Library/Connection/devicehandler.py
@@ -6,7 +6,7 @@ import serial.tools.list_ports
 import inspect
 import traceback
 from binascii import hexlify
-from edlclient.Library.utils import *
+from mtkclient.Library.utils import *
 
 class DeviceClass(metaclass=LogBase):
 


### PR DESCRIPTION
Fix Launching of GUI
file is using edl instead of the required mtk.  
This is in turn causing an eldclient error and preventing the GUI from launching