### PR TITLE
add pyserial dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     'colorama',
     'usb',
     'pyusb',
+    'pyserial',
     'pycryptodome',
     'PySide2',
     'mock'


### PR DESCRIPTION
I found pyserial is needed for installation.

This PR adds the dependency.﻿
