### PR TITLE
daconfig: fixup hw_code check when parsing DA loader(s)

### DIFF
--- a/mtkclient/Library/daconfig.py
+++ b/mtkclient/Library/daconfig.py
@@ -205,7 +205,7 @@ class DAconfig(metaclass=LogBase):
                     bootldr.seek(0x6C + (i * 0xDC))
                     da = DA(bootldr.read(0xDC))
                     da.setfilename(loader)
-                    if da.hw_code == 0x6592 and "5.1648" not in loader:
+                    if hex(da.hw_code) == 0x6592 and "5.1648" not in loader:
                         continue
                     if da.hw_code not in self.dasetup:
                         self.dasetup[da.hw_code] = [da]


### PR DESCRIPTION
* Commit https://github.com/bkerler/mtkclient/commit/e76c4704719f996b3c39b0fc32d33fd0472359a6 fixed support for MT6592. However, the hw_code check added in
  that change fails because '0x6592' is a hex value while da.hw_code is an int
  value and thus the tool crashes when trying to acquire the da_loader config.