### PR TITLE
Various updates

### DIFF
--- a/mtkclient/Library/daconfig.py
+++ b/mtkclient/Library/daconfig.py
@@ -205,8 +205,6 @@ class DAconfig(metaclass=LogBase):
                     bootldr.seek(0x6C + (i * 0xDC))
                     da = DA(bootldr.read(0xDC))
                     da.setfilename(loader)
-                    if da.hw_code == 0x6592 and "5.1648" not in loader:
-                        continue
                     if da.hw_code not in self.dasetup:
                         self.dasetup[da.hw_code] = [da]
                     else:

--- a/mtkclient/config/usb_ids.py
+++ b/mtkclient/config/usb_ids.py
@@ -9,4 +9,5 @@ default_ids = [
     [0x0FCE, 0xF200, -1], # Sony Brom
     [0x0FCE, 0xD1E9, -1], # Sony Brom XA1
     [0x0FCE, 0xD1E2, -1], # Sony Brom
+    [0x0FCE, 0xD1EC, -1], # Sony Brom L1
 ]


### PR DESCRIPTION
* Commit https://github.com/bkerler/mtkclient/commit/e76c4704719f996b3c39b0fc32d33fd0472359a6 fixed support for MT6592. However, the hw_code check added in
  that change causes the tool to fail when trying to acquire the loader config:
    - DAconfig - [LIB]: No da_loader config set up

* Removing the check seems to fix the problem (the tool configures the loader
  correctly). I'm not sure what the point of the check is (there is no loader
  with 5.1648 in its name), but since it seems to work fine without it, nuke
  it.