### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     'pyusb',
     'pyserial',
     'pycryptodome',
-    'PySide2',
+    'PySide6',
     'mock'
     ],
     author='B. Kerler',


### PR DESCRIPTION
This fixes an incorrect version in setup.py. PySide2 does not contain packages for newer python versions yet. This change worked for me without problems.

Please note that [requirements.txt](https://github.com/bkerler/mtkclient/blob/main/requirements.txt) also only references `pyside6`