### PR TITLE
Update mtk.bat (Fixed Crash)

### DIFF
--- a/mtk.bat
+++ b/mtk.bat
@@ -1,3 +1,3 @@
 @echo off
 title MTKClient
-python %~dp0\mtk %*
+python "%~dp0\mtk" %*


### PR DESCRIPTION
If there are spaces in the directory path, passing the path as an argument will cause the command line to fail (with an error that such directory does not exist) :)