### PR TITLE
Fix build error after latest pyproject.toml update. Replace license_file parameter with license_files (license_file parameter is deprecated) 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
+name="mtkclient"
+version="1.6.3"
 dependencies = [
     "pyusb",
     "pycryptodome",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='mtkclient',
-    version='1.6.3',
     packages=find_packages(),
     long_description=open("README.md").read(),
     scripts=['mtk','stage2'],


### PR DESCRIPTION
The build error:
```  parsed = self.parsers.get(option_name, lambda x: x)(value)
validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
Traceback (most recent call last):
  File "/home/vilez/Harddisk/mtkclient/setup.py", line 4, in <module>
    setup(
  File "/usr/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 159, in setup
    dist.parse_config_files()
  File "/usr/lib/python3.11/site-packages/setuptools/dist.py", line 898, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
  File "/usr/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 72, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 134, in read_configuration
    validate(subset, filepath)
  File "/usr/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 61, in validate
    raise ValueError(f"{error}\n{summary}") from None
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must contain ['name'] properties```

replace the deprecated parameter: ```/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
```

Deprecated parameter:
```
/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
```