### PR TITLE
Fix FileNotFound exception in mtk reset

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -747,10 +747,8 @@ class DA_handler(metaclass=LogBase):
         elif cmd == "reset":
             if os.path.exists(".state"):
                 os.remove(".state")
-                try:
+                if os.path.exists(os.path.join("logs", "hwparam.json")):
                     os.remove(os.path.join("logs", "hwparam.json"))
-                except FileNotFoundError:
-                    pass
             mtk.daloader.shutdown(bootmode=0)
             print("Reset command was sent. Disconnect usb cable to power off.")
         elif cmd == "da":

--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -747,7 +747,10 @@ class DA_handler(metaclass=LogBase):
         elif cmd == "reset":
             if os.path.exists(".state"):
                 os.remove(".state")
-                os.remove(os.path.join("logs", "hwparam.json"))
+                try:
+                    os.remove(os.path.join("logs", "hwparam.json"))
+                except FileNotFoundError:
+                    pass
             mtk.daloader.shutdown(bootmode=0)
             print("Reset command was sent. Disconnect usb cable to power off.")
         elif cmd == "da":


### PR DESCRIPTION
If logs don't exist for some reason, we don't need to trip up when deleting them, which prevents proper device shutdown.