### PR TITLE
MT8135

### DIFF
--- a/mtkclient/config/brom_config.py
+++ b/mtkclient/config/brom_config.py
@@ -1528,11 +1528,11 @@ hwconfig = {
         loader="mt8127_payload.bin"),  # ford,austin,tank #mhmm wdt, nochmal checken
     0x8135: chipconfig(  # var1
         watchdog=0x10000000,
-        # uart
+        uart=0x11002000,
         # brom_payload_addr
         da_payload_addr=0x12001000,
-        # pl_payload_addr
-        # gcpu_base
+        pl_payload_addr=0x80001000,
+        gcpu_base=0x11018000,
         # sej_base
         # cqdma_base
         # ap_dma_mem

--- a/mtkclient/config/usb_ids.py
+++ b/mtkclient/config/usb_ids.py
@@ -4,6 +4,7 @@ default_ids = [
     [0x0E8D, 0x2000, -1],  # MTK Preloader
     [0x0E8D, 0x2001, -1],  # MTK Preloader
     [0x0E8D, 0x20FF, -1],  # MTK Preloader
+    [0x0E8D, 0x3000, -1],  # MTK Preloader
     [0x1004, 0x6000, 2],  # LG Preloader
     [0x22d9, 0x0006, -1],  # OPPO Preloader
     [0x0FCE, 0xF200, -1],  # Sony Brom


### PR DESCRIPTION
* My Fire HD6 2014 (MT8135) seems to use 3000 instead of the (common) 2000 seen across other MTK devices.