### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,18 @@ requires-python = ">= 3.8"
 dependencies = [
     "pyusb",
     "pycryptodome",
+    "pycryptodomex",
     "colorama",
     "shiboken6", 
     "pyside6",
-    "mock"
+    "mock",
+    "pyserial",
+    "fusepy"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GPLv3 License",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
 ]
 keywords = ["mediatek", "mtk", "flashing", "reverse engineering", "firmware"]
@@ -35,14 +38,8 @@ keywords = ["mediatek", "mtk", "flashing", "reverse engineering", "firmware"]
 Repository = "https://github.com/bkerler/mtkclient.git"
 Issues = "https://github.com/bkerler/mtkclient/issues"
 
-[project.scripts]
-mtk = "mtk:main"
-stage2 = "stage2:main"
-
-[project.gui-scripts]
-mtk_gui = "mtk_gui:main"
-
 [tool.setuptools]
 # See also the MANIFEST.in file.
 # We want to install all the files in the package directories...
 include-package-data = true
+script-files = ["mtk", "stage2", "mtk_gui"]


### PR DESCRIPTION
Fix ModuleNotFoundError

System environment (not required):
ArchLinux
Python 3.12
pip 24.0

Bug Reproduction Steps:
```bash
$ python -m venv test
$ cd test 
$ . bin/activate
$ git clone --depth=1 https://github.com/bkerler/mtkclient
Cloning into 'mtkclient'...
remote: Enumerating objects: 1147, done.
remote: Counting objects: 100% (1147/1147), done.
remote: Compressing objects: 100% (491/491), done.
remote: Total 1147 (delta 768), reused 814 (delta 647), pack-reused 0
Receiving objects: 100% (1147/1147), 19.28 MiB | 5.82 MiB/s, done.
Resolving deltas: 100% (768/768), done.

$ cd mtkclient
$ pip install .                                              
Looking in indexes: https://mirrors.cernet.edu.cn/pypi/web/simple, https://mirrors.cloud.tencent.com/pypi/simple, https://mirrors.aliyun.com/pypi/simple, https://mirrors.163.com/pypi/simple
Processing /home/administrator/projects/test/mtkclient
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pyusb (from mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/15/a8/4982498b2ab44d1fcd5c49f07ea3795eab01601dc143b009d333fcace3b9/pyusb-1.2.1-py3-none-any.whl (58 kB)
Collecting pycryptodome (from mtkclient==2.0.0)
  Downloading https://mirrors.aliyun.com/pypi/packages/af/20/5f29ec45462360e7f61e8688af9fe4a0afae057edfabdada662e11bf97e7/pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 3.1 MB/s eta 0:00:00
Collecting colorama (from mtkclient==2.0.0)
  Downloading https://mirrors.aliyun.com/pypi/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting shiboken6 (from mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/ac/31/cd538b806b83c9d567e498c4c3d11e35baa9e989aadd5ec7c2caa52b571d/shiboken6-6.7.1-cp39-abi3-manylinux_2_28_x86_64.whl (188 kB)
Collecting pyside6 (from mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/84/f0/32ab2317ad1097c12fa9b34621c642babc979197e11a268ba4e02d1e6501/PySide6-6.7.1-cp39-abi3-manylinux_2_28_x86_64.whl (530 kB)
Collecting mock (from mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/6b/20/471f41173930550f279ccb65596a5ac19b9ac974a8d93679bcd3e0c31498/mock-5.1.0-py3-none-any.whl (30 kB)
Collecting PySide6-Essentials==6.7.1 (from pyside6->mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/5f/6e/387c24fe38523e2097af16e4f5a8b51643f900295088e204456784bca101/PySide6_Essentials-6.7.1-cp39-abi3-manylinux_2_28_x86_64.whl (87.6 MB)
Collecting PySide6-Addons==6.7.1 (from pyside6->mtkclient==2.0.0)
  Using cached https://mirrors.aliyun.com/pypi/packages/c4/81/e5fded14e4400e59ce22f071c9f7289e23c7772bb1cc40bf6bdc7d66b02e/PySide6_Addons-6.7.1-cp39-abi3-manylinux_2_28_x86_64.whl (137.4 MB)
Building wheels for collected packages: mtkclient
  Building wheel for mtkclient (pyproject.toml) ... done
  Created wheel for mtkclient: filename=mtkclient-2.0.0-py3-none-any.whl size=19947536 sha256=92dd1e004d6e50e1306c35aeb8754b7762e544cf1d4bfb0d7b99cbc111d2a916
  Stored in directory: /tmp/pip-ephem-wheel-cache-bt8lnb5l/wheels/e7/f5/a1/670279fb6bd6c6c0e31910b482e67dbff70abdef709aa6a7c8
Successfully built mtkclient
Installing collected packages: shiboken6, pyusb, pycryptodome, mock, colorama, PySide6-Essentials, PySide6-Addons, pyside6, mtkclient
Successfully installed PySide6-Addons-6.7.1 PySide6-Essentials-6.7.1 colorama-0.4.6 mock-5.1.0 mtkclient-2.0.0 pycryptodome-3.20.0 pyside6-6.7.1 pyusb-1.2.1 shiboken6-6.7.1

$ mtk 
Traceback (most recent call last):
  File "/home/***/projects/test/bin/mtk", line 5, in <module>
    from mtk import main
ModuleNotFoundError: No module named 'mtk'

$ mtk_gui
Traceback (most recent call last):
  File "/home/***/projects/test/bin/mtk_gui", line 5, in <module>
    from mtk_gui import main
ModuleNotFoundError: No module named 'mtk_gui'

$ stage2
Traceback (most recent call last):
  File "/home/***/projects/test/bin/stage2", line 5, in <module>
    from stage2 import main
ModuleNotFoundError: No module named 'stage2'
```