### PR TITLE
mtk_class: Use serial_handshake if serialportname provided

### DIFF
--- a/mtkclient/Library/mtk_class.py
+++ b/mtkclient/Library/mtk_class.py
@@ -202,7 +202,10 @@ class Mtk(metaclass=LogBase):
                 self.config.payloadfile = os.path.join(self.pathconfig.get_payloads_path(),
                                                        self.config.chipconfig.loader)
         if plt.runpayload(filename=self.config.payloadfile):
-            mtk.port.run_handshake()
+            if mtk.serialportname:
+                mtk.port.serial_handshake()
+            else:
+                mtk.port.handshake()
             return mtk
         else:
             self.error("Error on running kamakiri payload")


### PR DESCRIPTION
- Fixes:

EP_OUT = self.cdc.EP_OUT.write
^^^^^^^^^^^^^^^
AttributeError: 'serial_class' object has no attribute 'EP_OUT'