### PR TITLE
update GitHub actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,12 +13,12 @@ on:
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up Python3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
         cache: 'pip'


### PR DESCRIPTION
- ubuntu 24.04 is available ubuntu-latest still points to 22.04 

- upgrade setup-python action to v5