### PR TITLE
Fix incorrect comparison in runpayload method

### DIFF
--- a/mtkclient/Library/pltools.py
+++ b/mtkclient/Library/pltools.py
@@ -75,12 +75,12 @@ class PLTools(metaclass=LogBase):
             self.info(f"Couldn't open {filename} for reading.")
             return False
 
-        ack = self.exploit.runpayload(payload, ack, addr, dontack)
-        if ack == ack:
+        response_ack = self.exploit.runpayload(payload, ack, addr, dontack)
+        if response_ack == ack:
             self.info(f"Successfully sent payload: {filename}")
             self.mtk.daloader.patch = True
             return True
-        elif ack == b"\xc1\xc2\xc3\xc4":
+        elif response_ack == b"\xc1\xc2\xc3\xc4":
             if "preloader" in rf.name:
                 ack = self.mtk.port.usbread(4)
                 if ack == b"\xC0\xC0\xC0\xC0":


### PR DESCRIPTION
### Description

This pull request addresses an issue in the `runpayload` method where the if statement was incorrectly comparing the acknowledgement value with itself, which always returns true. The comparison has been corrected to properly compare the response acknowledgement (`response_ack`) with the expected `ack` value.

### Changes Made

- Corrected the if statement from `if ack == ack:` to `if response_ack == ack:`.
