### PR TITLE
Skip BROM exploitation when preloader is given through commandline argument

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -125,7 +125,13 @@ class DaHandler(metaclass=LogBase):
                                or self.mtk.config.target_config["sbc"])
                 if not hassecurity:
                     mtk.daloader.patch = True
-                mtk = mtk.bypass_security()  # Needed for dumping preloader
+
+                if preloader is None:
+                    self.info("Preloader is not supplied. Acquiring it through BROM exploit.")
+                    mtk = mtk.bypass_security()  # Needed for dumping preloader
+                else:
+                    self.info("Using supplied preloader. Skipping exploitation!")
+
                 if mtk is not None:
                     self.mtk = mtk
                     if preloader is None:


### PR DESCRIPTION
This PR skips BROM exploitation when the user-supplied preloader is given through a command line argument.

Through this change, BROM patched, but SBC/SLA/DAA disabled machines BROM mode can be supported. (i.e. MD-PH-001)