### PR TITLE
Fix expected type of default parameter for filename

### DIFF
--- a/mtkclient/Library/DA/xflash/extension/xflash.py
+++ b/mtkclient/Library/DA/xflash/extension/xflash.py
@@ -653,7 +653,7 @@ class XFlashExt(metaclass=LogBase):
             return False, writedata
         if self.xflash.writeflash(addr=partition.sector * self.mtk.daloader.daconfig.pagesize,
                                   length=len(writedata),
-                                  filename=None, wdata=writedata, parttype="user", display=True):
+                                  filename="", wdata=writedata, parttype="user", display=True):
             return True, "Successfully wrote seccfg."
         return False, "Error on writing seccfg config to flash."
 


### PR DESCRIPTION
None causes error for wrong type expected instead of empty string.