### PR TITLE
Add M0Rf30's instructions to install android udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ pip3 install .
 ```
 
 #### Install rules
+Follow M0Rf30's .[instructions](https://github.com/M0Rf30/android-udev-rules) or execute the following commands:
 ```
 sudo usermod -a -G plugdev $USER
 sudo usermod -a -G dialout $USER


### PR DESCRIPTION
The instructions to install android udev rules provided previously were not sufficient (especially for Arch Linux users). So I add a link to the repository from M0Rf30 where people can find more information