### PR TITLE
Fix partition slot handling in vbmeta patching for non-A/B devices

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -677,6 +677,8 @@ class DaHandler(metaclass=LogBase):
             tmp = self.da_read_partition("para")
         if tmp != b"":
             slot = tmp[0x800:0x802].decode('utf-8')
+            if slot == "\x00\x00":
+                slot = ""
         else:
             slot = ""
         return slot

--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -240,7 +240,7 @@ class DaHandler(metaclass=LogBase):
                                            length=rpartition.sectors * self.config.pagesize,
                                            filename="", parttype=parttype)
             return data
-        return None
+        return b""
 
     def da_write_partition(self, partitionname, data:bytes=None, parttype="user"):
         rpartition = None


### PR DESCRIPTION
This pull request fixes the following error encountered while patching vbmeta on non-A/B devices:

```
Preloader - 	CPU:			MT6761/MT6762/MT3369/MT8766B(Helio A20/P22/A22/A25/G25)
Preloader - 	HW version:		0x0
Preloader - 	WDT:			0x10007000
Preloader - 	Uart:			0x11002000
Preloader - 	Brom payload addr:	0x100a00
Preloader - 	DA payload addr:	0x201000
Preloader - 	CQ_DMA addr:		0x10212000
Preloader - 	Var1:			0x25
Preloader - Disabling Watchdog...
Preloader - HW code:			0x717
Preloader - Target config:		0x0
Preloader - 	SBC enabled:		False
Preloader - 	SLA enabled:		False
Preloader - 	DAA enabled:		False
Preloader - 	SWJTAG enabled:		False
Preloader - 	EPP_PARAM at 0x600 after EMMC_BOOT/SDMMC_BOOT:	False
Preloader - 	Root cert required:	False
Preloader - 	Mem read auth:		False
Preloader - 	Mem write auth:		False
Preloader - 	Cmd 0xC8 blocked:	False
Preloader - Get Target info
Preloader - 	HW subcode:		0x8a00
Preloader - 	HW Ver:			0xca01
Preloader - 	SW Ver:			0x200
Preloader - ME_ID:			2FB752521B0B44385FDE084F0F134B13
Preloader - SOC_ID:			4765203D49D946BC53B6C1E341A40EE57A006732C95042C0D2030374E2A86582
DaHandler - Device is unprotected.
DaHandler - Device is in Preloader-Mode.
DAXFlash - Uploading xflash stage 1 from MTK_DA_V5.bin
XFlashExt - Patching da1 ...
Mtk - Patched "Patched loader msg" in preloader
Mtk - Patched "hash_check" in preloader
Mtk - Patched "Patched loader msg" in preloader
Mtk - Patched "get_vfy_policy" in preloader
XFlashExt - Patching da2 ...
XFlashExt - Security check patched
XFlashExt - DA version anti-rollback patched
XFlashExt - SBC patched to be disabled
XFlashExt - Register read/write not allowed patched
DAXFlash - Successfully uploaded stage 1, jumping ..
Preloader - Jumping to 0x200000
Preloader - Jumping to 0x200000: ok.
DAXFlash - Successfully received DA sync
DAXFlash - Uploading stage 2...
DAXFlash - Upload data was accepted. Jumping to stage 2...
DAXFlash - Boot to succeeded.
DAXFlash - Successfully uploaded stage 2
DAXFlash - DA SLA is disabled
DAXFlash - EMMC FWVer:      0x0
DAXFlash - EMMC ID:         DV4032
DAXFlash - EMMC CID:        45010044563430333201256003478951
DAXFlash - EMMC Boot1 Size: 0x400000
DAXFlash - EMMC Boot2 Size: 0x400000
DAXFlash - EMMC GP1 Size:   0x0
DAXFlash - EMMC GP2 Size:   0x0
DAXFlash - EMMC GP3 Size:   0x0
DAXFlash - EMMC GP4 Size:   0x0
DAXFlash - EMMC RPMB Size:  0x1000000
DAXFlash - EMMC USER Size:  0x747c00000
DAXFlash - HW-CODE         : 0x717
DAXFlash - HWSUB-CODE      : 0x8A00
DAXFlash - HW-VERSION      : 0xCA01
DAXFlash - SW-VERSION      : 0x200
DAXFlash - CHIP-EVOLUTION  : 0x0
DAXFlash - DA-VERSION      : 1.0
DAXFlash - Extensions were accepted. Jumping to extensions...
DAXFlash - Boot to succeeded.
DAXFlash - DA Extensions successfully added
Traceback (most recent call last):
  File "/home/hitori/tools/mtkclient/./mtk.py", line 1021, in <module>
    main()
  File "/home/hitori/tools/mtkclient/./mtk.py", line 1017, in main
    mtk = Main(args).run(parser)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hitori/tools/mtkclient/mtkclient/Library/mtk_main.py", line 684, in run
    da_handler.handle_da_cmds(mtk, cmd, self.args)
  File "/home/hitori/tools/mtkclient/mtkclient/Library/DA/mtk_da_handler.py", line 942, in handle_da_cmds
    self.da_vbmeta(vbmode=vbmode)
  File "/home/hitori/tools/mtkclient/mtkclient/Library/DA/mtk_da_handler.py", line 188, in da_vbmeta
    slot = self.get_current_slot()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hitori/tools/mtkclient/mtkclient/Library/DA/mtk_da_handler.py", line 679, in get_current_slot
    slot = tmp[0x800:0x802].decode('utf-8')
           ~~~^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```