### PR TITLE
seccfg parse: legacy algorithms are now tried last to fix parse hwtype=V3

### DIFF
--- a/mtkclient/Library/Hardware/hwcrypto_dxcc.py
+++ b/mtkclient/Library/Hardware/hwcrypto_dxcc.py
@@ -1128,7 +1128,7 @@ class Dxcc(metaclass=LogBase):
         keylength = 0x10
         self.tzcc_clk(1)
         dstaddr = self.da_payload_addr - 0x300
-        pubkey = self.sasi_bsv_pubkey_hash_get(SASI_SB_HASH_BOOT_KEY_256B)
+        pubkey = self.sasi_bsv_pub_key_hash_get(SASI_SB_HASH_BOOT_KEY_256B)
         derivedkey = self.sbrom_key_derivation(1, key, salt, keylength, dstaddr)
         hash = hashlib.sha256(pubkey+derivedkey).digest()
         self.tzcc_clk(0)

--- a/mtkclient/Library/Hardware/seccfg.py
+++ b/mtkclient/Library/Hardware/seccfg.py
@@ -52,19 +52,20 @@ class SecCfgV4(metaclass=LogBase):
         if _hash == dec_hash:
             self.hwtype = "SW"
         else:
-            dec_hash = self.hwc.sej.sej_sec_cfg_hw(self.hash, False)
+            dec_hash = self.hwc.sej.sej_sec_cfg_hw_V3(self.hash, False)
             if _hash == dec_hash:
-                self.hwtype = "V2"
+                self.hwtype = "V3"
             else:
-                dec_hash = self.hwc.sej.sej_sec_cfg_hw_V3(self.hash, False)
+                dec_hash = self.hwc.sej.sej_sec_cfg_hw_V3(self.hash, False, legacy=True)
                 if _hash == dec_hash:
-                    self.hwtype = "V3"
+                    self.hwtype = "V4"
                 else:
-                    dec_hash = self.hwc.sej.sej_sec_cfg_hw_V3(self.hash, False, legacy=True)
+                    dec_hash = self.hwc.sej.sej_sec_cfg_hw(self.hash, False)
                     if _hash == dec_hash:
-                        self.hwtype = "V4"
+                        self.hwtype = "V2"
                     else:
                         return False
+        self.info(f"hwtype found: {self.hwtype}")
 
         """
         LKS_DEFAULT = 0x01


### PR DESCRIPTION
Fix issue #1345 and probably others related to MediaTek Helio P90T (MT8788).

For SecCfgV4, trying to parse an algorithm using legacy code before the new method (hwtype V3) can have the unintended of altering the resulting hash. Trying to parse for SW or V3 before V4 and V2 have fixed it.

Suggestion: review the underlying code to identify the root cause as of why the legacy code has a side effect of altering the resulting hash of algorithm not using the legacy code.