### PR TITLE
I added openssl 1.1.1 on mtkclient setup description for windows. Without scrypt dependency install fails to build during the install

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ pip3 install -r requirements.txt
 #### Install Winfsp (for fuse)
 Download and install [here](https://winfsp.dev/rel/)
 
+#### Install OpenSSL (for python scrypt dependency)
+Download and install [here](https://sourceforge.net/projects/openssl-for-windows/files/)
+
 #### Grab files and install
 ```
 git clone https://github.com/bkerler/mtkclient

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ pip3 install -r requirements.txt
 #### Install Winfsp (for fuse)
 Download and install [here](https://winfsp.dev/rel/)
 
-#### Install OpenSSL (for python scrypt dependency)
+#### Install OpenSSL 1.1.1 (for python scrypt dependency)
 Download and install [here](https://sourceforge.net/projects/openssl-for-windows/files/)
 
 #### Grab files and install


### PR DESCRIPTION
As from title, openssl 1.1.1 seems to be required so I think that it can be added to the setup for windows as python scrypt dependency needs it