### PR TITLE
refactor: replace exit() with sys.exit() in mtk.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,2 @@
-__pycache__
-# Compiled python modules.
-*.pyc
-.idea
-DA_*.bin
-
-# Setuptools distribution folder.
-/dist/
-
-# Python egg metadata, regenerated from source files by setuptools.
-/*.egg-info
-/*.egg
-
-# Pyinstaller stuff
-build
-dist
+# Created by venv; see https://docs.python.org/3/library/venv.html
+*

--- a/mtk.py
+++ b/mtk.py
@@ -2,6 +2,7 @@
 # MTK Flash Client (c) B.Kerler 2018-2024.
 # Licensed under GPLv3 License
 import argparse
+import sys
 from mtkclient.Library.mtk_main import Main, metamodes
 
 info = "MTK Flash/Exploit Client Public V2.0.1 (c) B.Kerler 2018-2024"
@@ -1012,7 +1013,7 @@ def main():
     cmd = args.cmd
     if cmd not in cmds:
         parser.print_help()
-        exit(0)
+        sys.exit(1)
 
     mtk = Main(args).run(parser)
 


### PR DESCRIPTION
causing errors in compilation to windows exe
Error:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: underlying buffer has been detached
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: underlying buffer has been detached