### PR TITLE
Replace mock dependency with unittest.mock

### DIFF
--- a/mtk_gui.py
+++ b/mtk_gui.py
@@ -3,10 +3,10 @@
 # Licensed under GPLv3 License
 import sys
 import time
-import mock
 import threading
 import logging
 import ctypes
+from unittest import mock
 from functools import partial
 from PySide6.QtCore import Qt, QVariantAnimation, Signal, QObject, QSize, QTranslator, QLocale, QLibraryInfo, \
     Slot, QCoreApplication

--- a/mtkclient/gui/eraseFlashPartitions.py
+++ b/mtkclient/gui/eraseFlashPartitions.py
@@ -1,6 +1,6 @@
 import sys
-import mock
 
+from unittest import mock
 from PySide6.QtCore import QObject, Signal
 from mtkclient.gui.toolkit import FDialog
 from mtkclient.gui.toolkit import trap_exc_during_debug, asyncThread

--- a/mtkclient/gui/readFlashPartitions.py
+++ b/mtkclient/gui/readFlashPartitions.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import mock
+from unittest import mock
 from PySide6.QtCore import QObject, Signal
 from mtkclient.gui.toolkit import convert_size, FDialog, trap_exc_during_debug, asyncThread
 

--- a/mtkclient/gui/writeFlashPartitions.py
+++ b/mtkclient/gui/writeFlashPartitions.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import mock
+from unittest import mock
 from PySide6.QtCore import QObject, Signal
 from mtkclient.gui.toolkit import trap_exc_during_debug, asyncThread, FDialog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "colorama",
     "shiboken6", 
     "pyside6",
-    "mock",
     "pyserial",
     "fusepy"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pycryptodomex
 colorama
 shiboken6
 pyside6
-mock
 pyserial
 flake8
 keystone-engine

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,6 @@ mkShell {
     fusepy
     keystone
     keystone-engine
-    mock
     pycryptodome
     pycryptodomex
     pyserial


### PR DESCRIPTION
This library has been merged into the standard library back in Python 3.3, so we can safely use it without a dependency.