### PR TITLE
XFlash: load DA extensions below the 256MB address mark

### DIFF
--- a/mtkclient/Library/DA/xflash/xflash_lib.py
+++ b/mtkclient/Library/DA/xflash/xflash_lib.py
@@ -285,7 +285,7 @@ class DAXFlash(metaclass=LogBase):
                 if self.usbwrite(pkt1):
                     if self.usbwrite(param):
                         if self.send_data(da):
-                            if addr == 0x68000000:
+                            if addr == 0x4FFF0000:
                                 if display:
                                     self.info("Extensions were accepted. Jumping to extensions...")
                             else:
@@ -1241,7 +1241,7 @@ class DAXFlash(metaclass=LogBase):
                     daextdata = self.xft.patch()
                     if daextdata is not None:
                         self.daext = False
-                        if self.boot_to(addr=0x68000000, da=daextdata):
+                        if self.boot_to(addr=0x4FFF0000, da=daextdata):
                             ret = self.send_devctrl(XCmd.CUSTOM_ACK)
                             status = self.status()
                             if status == 0x0 and unpack("<I", ret)[0] == 0xA1A2A3A4:


### PR DESCRIPTION
DA extensions are loaded starting from 640MB of the DRAM. That causes devices with less memory to hang on the `boot_to` call:
```
DAXFlash - Extensions were accepted. Jumping to extensions...
DAXFlash
DAXFlash - [LIB]: Stage was't executed. Maybe dram issue ?.
```
Fix it by adjusting the load address.

(I see no reason to decrease it even further but at some point we might overwrite working memory used by the DA.)