### PR TITLE
XFlash: export the detected page size for NAND storage

### DIFF
--- a/mtkclient/Library/DA/xflash/xflash_lib.py
+++ b/mtkclient/Library/DA/xflash/xflash_lib.py
@@ -580,6 +580,8 @@ class DAXFlash(metaclass=LogBase):
             pos += 1
             nand.nand_id = bytearray(resp[pos:pos + 12])
             if nand.type != 0:
+                self.mtk.config.pagesize = nand.page_size
+                self.mtk.daloader.daconfig.pagesize = nand.page_size
                 if display:
                     self.info(f"NAND Pagesize:   {hex(nand.page_size)}")
                     self.info(f"NAND Blocksize:  {hex(nand.block_size)}")


### PR DESCRIPTION
For NAND the minimum read/write size is usually larger than the default 512 bytes. Make functions aware of the page size detected.