### PR TITLE
Add missing --filename switch to `da peek`

### DIFF
--- a/mtk.py
+++ b/mtk.py
@@ -245,7 +245,7 @@ def main():
     da_peek = da_subs.add_parser("peek", parents=[base])
     da_peek.add_argument('address', type=str, help="Address to read from (hex value)")
     da_peek.add_argument('length', type=str, help="Length to read")
-    da_peek.add_argument('--filename', type=str, help="Filename to write data into")
+    da_peek.add_argument('--filename', type=str, help="Save to file (optional)")
 
     da_subs.add_parser("efuse", parents=[base], help="Read efuses")
     da_subs.add_parser("generatekeys", parents=[base], help="Generate keys")

--- a/mtk.py
+++ b/mtk.py
@@ -245,6 +245,7 @@ def main():
     da_peek = da_subs.add_parser("peek", parents=[base])
     da_peek.add_argument('address', type=str, help="Address to read from (hex value)")
     da_peek.add_argument('length', type=str, help="Length to read")
+    da_peek.add_argument('--filename', type=str, help="Filename to write data into")
 
     da_subs.add_parser("efuse", parents=[base], help="Read efuses")
     da_subs.add_parser("generatekeys", parents=[base], help="Generate keys")


### PR DESCRIPTION
fixes mtk.py crashing with this

```
Main - Handling da commands ...
Traceback (most recent call last):
  File "/home/nadwey/Downloads/mtkclient/mtkclient/mtk.py", line 341, in <module>
    sys.exit(main() or 0)
             ^^^^^^
  File "/home/nadwey/Downloads/mtkclient/mtkclient/mtk.py", line 337, in main
    return mtk.run(parser)
           ^^^^^^^^^^^^^^^
  File "/home/nadwey/Downloads/mtkclient/mtkclient/mtkclient/Library/mtk_main.py", line 728, in run
    da_handler.handle_da_cmds(mtk, cmd, self.args)
  File "/home/nadwey/Downloads/mtkclient/mtkclient/mtkclient/Library/DA/mtk_da_handler.py", line 1369, in handle_da_cmds
    filename = args.filename
               ^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'filename'
```
