### PR TITLE
 Fixed missing --filename parameters for preloader/brom/sram dump, and also added preloader feature name, as you see

### DIFF
--- a/mtk.py
+++ b/mtk.py
@@ -231,7 +231,6 @@ def main():
     cmd_peek = subparsers.add_parser("peek", help=CMDS_HELP["peek"], parents=[base])
     cmd_peek.add_argument('address', help='Address to read from memory')
     cmd_peek.add_argument('length', help='Bytes to read from memory')
-    #cmd_peek.add_argument("--filename", help="Save to file (optional)")
 
     stage = subparsers.add_parser("stage", help=CMDS_HELP["stage"], parents=[base])
     stage.add_argument('--verifystage2', help='Verify if stage2 data has been written correctly')

--- a/mtk.py
+++ b/mtk.py
@@ -102,6 +102,11 @@ def add_gpt_group(parser):
     g.add_argument('--parttype', help='Partition type (user/boot1/rpmb/lu0 etc.)')
     g.add_argument('--skip', help='Skip partitions (comma separated names)')
 
+def add_specific_group(parser):
+    g = parser.add_argument_group("Specific argument")
+    g.add_argument('--filename', type=str, help='Optional filename')
+
+
 
 # ================== Base Parser ==================
 
@@ -115,6 +120,7 @@ def create_base_parser():
     add_debug_group(parser)
     add_exploit_group(parser)
     add_gpt_group(parser)
+    add_specific_group(parser)
     return parser
 
 
@@ -222,18 +228,17 @@ def main():
     subparsers.add_parser("gettargetconfig", help=CMDS_HELP["gettargetconfig"], parents=[base])
     subparsers.add_parser("logs", help=CMDS_HELP["logs"], parents=[base])
 
-    cmd_peek=subparsers.add_parser("peek", help=CMDS_HELP["peek"], parents=[base])
+    cmd_peek = subparsers.add_parser("peek", help=CMDS_HELP["peek"], parents=[base])
     cmd_peek.add_argument('address', help='Address to read from memory')
     cmd_peek.add_argument('length', help='Bytes to read from memory')
-    cmd_peek.add_argument("--filename", help="Save to file (optional)")
+    #cmd_peek.add_argument("--filename", help="Save to file (optional)")
 
-    stage=subparsers.add_parser("stage", help=CMDS_HELP["stage"], parents=[base])
+    stage = subparsers.add_parser("stage", help=CMDS_HELP["stage"], parents=[base])
     stage.add_argument('--verifystage2', help='Verify if stage2 data has been written correctly')
     stage.add_argument('--stage2', help='Set stage2 filename')
     stage.add_argument('--stage2addr', help='Set stage2 loading address')
-    stage.add_argument('--filename', help='Set stage1 loader filename')
 
-    plstage=subparsers.add_parser("plstage", help=CMDS_HELP["plstage"], parents=[base])
+    plstage = subparsers.add_parser("plstage", help=CMDS_HELP["plstage"], parents=[base])
     plstage.add_argument('--startpartition', help='Option for plstage - Boot to (lk, tee1)')
     plstage.add_argument('--pl', help='pl stage filename (optional)')
 
@@ -245,7 +250,7 @@ def main():
     da_peek = da_subs.add_parser("peek", parents=[base])
     da_peek.add_argument('address', type=str, help="Address to read from (hex value)")
     da_peek.add_argument('length', type=str, help="Length to read")
-    da_peek.add_argument('--filename', type=str, help="Save to file (optional)")
+
 
     da_subs.add_parser("efuse", parents=[base], help="Read efuses")
     da_subs.add_parser("generatekeys", parents=[base], help="Generate keys")

--- a/mtkclient/Library/mtk_main.py
+++ b/mtkclient/Library/mtk_main.py
@@ -482,7 +482,7 @@ class Main(metaclass=LogBase):
                 if rmtk.port.cdc.vid != 0xE8D or rmtk.port.cdc.pid != 0x0003:
                     self.warning("We couldn't enter preloader.")
                 plt = PLTools(rmtk, self.__logger.level)
-                data, filename = plt.run_dump_preloader(self.args.ptype)
+                data, filename = plt.run_dump_preloader(self.args.ptype, self.args.filename)
                 if filename is None:
                     filename = "preloader.bin"
                 if data is not None:

--- a/mtkclient/Library/pltools.py
+++ b/mtkclient/Library/pltools.py
@@ -158,19 +158,21 @@ class PLTools(metaclass=LogBase):
                 self.error(f"Error on sending payload: {pfilename}")
         return False
 
-    def run_dump_preloader(self, filename):
+    def run_dump_preloader(self, ptype, filename):
         pfilename = os.path.join(self.pathconfig.get_payloads_path(), "generic_preloader_dump_payload.bin")
         if type(self.exploit) is Kamakiri or type(self.exploit) is Kamakiri2:
             self.info("Kamakiri / DA Run")
             if self.runpayload(filename=pfilename, ack=0xC1C2C3C4, offset=0):
-                data, filename = self.exploit.dump_preloader()
+                data, filename_tools = self.exploit.dump_preloader()
+                if filename is None:
+                    return data, filename_tools
                 return data, filename
             else:
                 self.error(f"Error on sending payload: {pfilename}")
                 return None, None
         else:
-            if self.exploit.dump_brom(filename):
-                self.info(f"Preloader dumped as: {filename}")
+            if self.exploit.dump_brom(ptype):
+                self.info(f"Preloader dumped as: {ptype}")
                 return True
             else:
                 self.error("Error on dumping preloader")


### PR DESCRIPTION
## Fixed missing --filename parameters for preloader/brom/sram dump
Currently, if you try to use the dumpbrom or dumpsram commands, mtkclient will return the error AttributeError: 'Namespace' object has no attribute 'filename'
<details>
<summary>dumpbrom_log_1</summary>
Preloader

Preloader - [LIB]: ←[33mAuth file is required. Use --auth option.←[0m

Traceback (most recent call last):
  File "P:\mtkclient\mtkclient_2.1.2\mtkclient_2.1.2_0.0.9\mtk.py", line 342, in <module>
    sys.exit(main() or 0)
             ~~~~^^

  File "P:\mtkclient\mtkclient_2.1.2\mtkclient_2.1.2_0.0.9\mtk.py", line 338, in main
    return mtk.run(parser)
           ~~~~~~~^^^^^^^^

  File "P:\mtkclient\mtkclient_2.1.2\mtkclient_2.1.2_0.0.9\mtkclient\Library\mtk_main.py", line 467, in run
    filename = self.args.filename
               ^^^^^^^^^^^^^^^^^^

AttributeError: 'Namespace' object has no attribute 'filename'

</details>

And when trying to use the --filename argument, an error appears: unrecognized arguments: --filename brom.bin
<details>
<summary>dumpbrom_log_2</summary>
python mtk.py dumpbrom --filename brom.bin

usage: mtk.py [-h] [--vid VID] [--pid PID] [--serialport [SERIALPORT]]
              [--noreconnect] [--stock] [--uartloglevel UARTLOGLEVEL]
              [--loglevel LOGLEVEL] [--write_preloader_to_file]
              [--generatekeys] [--iot] [--socid] [--auth AUTH] [--cert CERT]
              [--debugmode] [--loader LOADER] [--preloader PRELOADER]
              [--ptype PTYPE] [--var1 VAR1] [--uart_addr UART_ADDR]
              [--da_addr DA_ADDR] [--brom_addr BROM_ADDR] [--mode MODE]
              [--wdt WDT] [--skipwdt] [--crash] [--appid APPID]
              [--sectorsize SECTORSIZE]
              [--gpt-num-part-entries GPT_NUM_PART_ENTRIES]
              [--gpt-part-entry-size GPT_PART_ENTRY_SIZE]
              [--gpt-part-entry-start-lba GPT_PART_ENTRY_START_LBA]
              [--parttype PARTTYPE] [--skip SKIP]
              command ...
mtk.py: error: unrecognized arguments: --filename brom.bin
</details>

## Declaring the "--filename" argument as public
I removed the individual --filename arguments from cmd_peek , stage , and da_peek . I thought allowing everyone to use --filename was simpler and more accurate than adding the same argument separately for three more commands.

Anyone who used --filename can still use it. I tried to identify any errors that could cause incorrect use of --filename, but I didn't find any. mtkclient ignores this parameter where it's not needed.


I was only able to discover that with commands like w,r and the like, --filename is more important than simple filename
<details>
<summary>example</summary>

If you use the command python 
`mtk.py w lk lk.bin --filename lk_2.bin`
Then, lk_2.bin will be written to the lk partition on the device. The same applies to the write commands, but I didn't think this was critical, as it could be resolved without using the additional --filename argument.
</details>

## I also fixed a bug from version 2.0.1, where it was impossible to set the preloader name when using dumppreloader
I fixed the preloader dump initialization function so that it would only use the vendor name if there is no user name.