### PR TITLE
fix: progress overflow #8

### DIFF
--- a/mtk_gui.py
+++ b/mtk_gui.py
@@ -150,7 +150,7 @@ class SerialPortDialog(QDialog):
 class DeviceHandler(QObject):
     sendToLogSignal = Signal(str)
     update_status_text = Signal(str)
-    sendToProgressSignal = Signal(int)
+    sendToProgressSignal = Signal(object)
     da_handler = None
 
     def __init__(self, parent, preloader: str = None, loader: str = None, loglevel=logging.INFO, *args, **kwargs):
@@ -354,7 +354,7 @@ class MainWindow(QMainWindow):
         self.ui.erasepreloaderbtn.setEnabled(True)
         self.ui.eraserpmbbtn.setEnabled(True)
 
-    @Slot(int)
+    @Slot(object)
     def updateProgress(self, progress):
         try:
             self.Status["currentPartitionSizeDone"] = progress

--- a/mtkclient/gui/toolkit.py
+++ b/mtkclient/gui/toolkit.py
@@ -103,7 +103,7 @@ def convert_size(size_bytes):
 class asyncThread(QThread):
     sendToLogSignal = Signal(str)
     sendUpdateSignal = Signal()
-    sendToProgressSignal = Signal(int)
+    sendToProgressSignal = Signal(object)
     update_status_text = Signal(str)
 
     def __init__(self, parent, n, function, parameters):


### PR DESCRIPTION
error message :
mtkclient\mtkclient\Library\gui_utils.py:99: RuntimeWarning: libshiboken: Overflow: Value 2375024640 exceeds limits of type  [signed] "int" (4bytes).