### PR TITLE
Add MT6575 kamakiri2 addresses

### DIFF
--- a/mtkclient/config/brom_config.py
+++ b/mtkclient/config/brom_config.py
@@ -714,6 +714,7 @@ hwconfig = {
     0x6575: Chipconfig(  # var1
         watchdog=0xC0000000,
         uart=0xC1009000,
+        brom_payload_addr=0xf0000a00,
         da_payload_addr=0xc2001000,
         pl_payload_addr=0xc2058000,
         # gcpu_base
@@ -722,6 +723,11 @@ hwconfig = {
         # cqdma_base
         ap_dma_mem=0xC100119C,
         # blacklist
+        send_ptr=(0xf00025fc,0xffffa0a0),
+        cmd_handler=0xffffad5c,
+        brom_register_access=(0xffffa3aa, 0xffffa4c4),
+        meid_addr=0xf0002af4,
+        efuse_addr=0xc1019000,
         damode=DAmodes.LEGACY,
         dacode=0x6575,
         name="MT6575/MT6577/MT8317"),


### PR DESCRIPTION
Adds addresses needed for kamakiri2 for MT6575.
I took these from a [brom dump I made a while ago](https://github.com/Zenofex/SoC-BootROMs/blob/main/mediatek/mt6575.bootrom.bin).
The brom base is 0xFFFF0000.

Unfortunately, the new mtkclient doesn't include the payloads source code, so I couldn't port the payload for it, and the generic patcher assumes the bootrom to be at 0x0.

Also, I can confirm all the other already present addresses match (wdt, uart, pl etc) for my hw variant (0xCA00). I do not own the 0xCB00 variant to verify this, but I assume the addresses are the same