### PR TITLE
xml_lib: Fix Carbonara check for V6 devices

### DIFF
--- a/mtkclient/Library/DA/xmlflash/xml_lib.py
+++ b/mtkclient/Library/DA/xmlflash/xml_lib.py
@@ -615,7 +615,7 @@ class DAXML(metaclass=LogBase):
             self.hakujoudai = Hakujoudai(self.mtk, self.loglevel)
 
             if not self.mtk.daloader.patch and not self.mtk.config.stock:
-                if self.mtk.config.target_config["sbc"] and self.carbonara.check_for_carbonara_patched(self.daconfig.da1):
+                if self.mtk.config.target_config["sbc"] and not self.carbonara.check_for_carbonara_patched(self.daconfig.da1):
                     loaded = self.carbonara.patchda1_and_upload_da2()
                     if loaded:
                         self.mtk.daloader.patch = True


### PR DESCRIPTION
The current code was improperly checking whether Carbonara could be used, causing mtkclient to attempt the exploit on patched devices and hang.

This fixes the issue and falls back to heapbait (if vulnerable) instead.