### PR TITLE
fix: MT6771 (0x6771) infinite timeout during flash read — move to two-write ACK path

### DIFF
--- a/mtkclient/Library/DA/xflash/xflash_lib.py
+++ b/mtkclient/Library/DA/xflash/xflash_lib.py
@@ -84,10 +84,10 @@ class DAXFlash(metaclass=LogBase):
 
     def ack(self, rstatus=True):
         try:
-            if self.mtk.config.chipconfig.dacode in [0x6781,0x6771]:
+            if self.mtk.config.chipconfig.dacode in [0x6781]:
                 stmp = pack("<IIII", self.cmd.MAGIC, self.data_type.DT_PROTOCOL_FLOW, 4, 0)
                 self.usbwrite(stmp)
-            else: # needed for 0x6750, 0x6762, 0x6785, 0x6761
+            else: # needed for 0x6750, 0x6762, 0x6785, 0x6761, 0x6771
                 stmp = pack("<III", self.cmd.MAGIC, self.data_type.DT_PROTOCOL_FLOW, 4)
                 data = pack("<I", 0)
                 self.usbwrite(stmp)


### PR DESCRIPTION
## Bug Description

After commit `343b649` ("Update DACODE check in ack method"), all flash read operations on **MT6771/Helio P60** devices (dacode `0x6771`, HW code `0x788`) hang indefinitely with repeated `"Timed out"` errors in the USB layer.

This affects any DA command that reads from flash, including:
- `python mtk.py da seccfg unlock`
- `python mtk.py da seccfg lock`  
- Any partition read operations

### Affected Devices
- **Nokia 5.1 Plus** (X5) — MT6771/Helio P60
- Potentially all MT6771, MT8385, MT8183, MT8666 (Helio P60/P70/G80) variants with dacode `0x6771`

## Root Cause

The `ack()` method in `DAXFlash` (`mtkclient/Library/DA/xflash/xflash_lib.py`) sends an acknowledgment packet to the Download Agent (DA) after reading flash data. There are two code paths:

1. **Single-write path**: Packs the 12-byte header + 4-byte data into one 16-byte `struct` and sends it as a single `usbwrite()` call
2. **Two-write path**: Sends the 12-byte header and 4-byte data as two separate `usbwrite()` calls

Commit `343b649` moved `0x6771` from the two-write path into the single-write path (replacing `0x6785`):

```python
# Before (working):
if self.mtk.config.chipconfig.dacode in [0x6781, 0x6785]:
    stmp = pack("<IIII", ...)  # single 16-byte write
    self.usbwrite(stmp)
else:  # 0x6750, 0x6762, 0x6785, 0x6761 — and implicitly 0x6771
    stmp = pack("<III", ...)   # 12-byte header
    data = pack("<I", 0)       # 4-byte data
    self.usbwrite(stmp)
    self.usbwrite(data)

# After 343b649 (broken for 0x6771):
if self.mtk.config.chipconfig.dacode in [0x6781, 0x6771]:  # <-- 0x6771 moved here
    stmp = pack("<IIII", ...)  # single 16-byte write
    self.usbwrite(stmp)
```

The DA firmware on MT6771 expects the ACK as **two separate USB packets**. When it receives a single 16-byte transfer, it reads the first 12 bytes (header), but the remaining 4 bytes are consumed in the same USB bulk transfer and effectively lost. The DA then waits forever for the 4-byte data portion that will never arrive as a separate packet. The host side loops on `"Timed out"` trying to read the status response that the DA will never send.

## Fix

Move `0x6771` back to the two-write ACK path:

```python
if self.mtk.config.chipconfig.dacode in [0x6781]:
    stmp = pack("<IIII", ...)  # single 16-byte write (only 0x6781)
    self.usbwrite(stmp)
else:  # 0x6750, 0x6762, 0x6785, 0x6761, 0x6771
    stmp = pack("<III", ...)   # 12-byte header
    data = pack("<I", 0)       # 4-byte data  
    self.usbwrite(stmp)
    self.usbwrite(data)
```

## Testing

Tested on a **Nokia 5.1 Plus** (MT6771/Helio P60, HW code `0x788`):

- **Before fix**: `python mtk.py da seccfg unlock` hangs after GPT read with infinite `"Timed out"` loop
- **After fix**: Command completes successfully in ~6 minutes, seccfg written, bootloader unlocked

### Debug log sequence (before fix)
```
DAXFlash - Boot to succeeded.
Main - Handling da commands ...
[reads GPT partition table successfully]
TX: efeeeefe010000000400000000000000   <-- ACK sent as single 16-byte write
Timed out                               <-- DA never responds
Timed out                               <-- infinite loop
...
```

### After fix
```
Main - Handling da commands ...
XFlashExt - Detected V4 Lockstate
Sej - AES128 CBC - HACC init/run/terminate
SecCfgV4 - hwtype found: V3
Done |██████████| 100.0% Write: (0x200/0x200),0.00 MB/s
DaHandler - Successfully wrote seccfg.
```