### PR TITLE
Switch from fusepy to mfusepy

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -15,7 +15,7 @@ from mtkclient.config.brom_config import Efuse, DAmodes
 from mtkclient.Library.Filesystem.mtkdafs import MtkDaFS
 
 try:
-    from fuse import FUSE
+    from mfusepy import FUSE
 except ImportError:
     FUSE = None
 

--- a/mtkclient/Library/Filesystem/mtkdafs.py
+++ b/mtkclient/Library/Filesystem/mtkdafs.py
@@ -9,7 +9,7 @@ if not os.environ.get('FUSE_LIBRARY_PATH') and os.name == 'nt':
                           os.path.join(os.path.dirname(__file__),
                                        r"bin\winfsp-%s.dll" % ("x64" if sys.maxsize > 0xffffffff else "x86")))
 try:
-    from fuse import Operations, LoggingMixIn
+    from mfusepy import Operations, LoggingMixIn
 
     class MtkDaFS(LoggingMixIn, Operations):
         def __init__(self, da_handler, rw=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "shiboken6", 
     "pyside6",
     "pyserial",
-    "fusepy"
+    "mfusepy"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ keystone-engine
 capstone
 unicorn
 keystone
-fusepy
+mfusepy
 

--- a/uv.lock
+++ b/uv.lock
@@ -16,18 +16,37 @@ wheels = [
 ]
 
 [[package]]
-name = "fusepy"
-version = "3.0.1"
+name = "mfusepy"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/0b/4506cb2e831cea4b0214d3625430e921faaa05a7fb520458c75a2dbd2152/fusepy-3.0.1.tar.gz", hash = "sha256:72ff783ec2f43de3ab394e3f7457605bf04c8cf288a2f4068b4cde141d4ee6bd", size = 11519, upload-time = "2018-09-17T00:14:52.666Z" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/09/b9a9e61ae0845c3de0249772dfee2294d269a7d644a9778bc42df97af6ae/mfusepy-1.1.1.tar.gz", hash = "sha256:3647727a6e7775d47fdeff61355935f1ed5edb31c5124d233138f2a91ea01f9f", size = 24891, upload-time = "2025-07-07T21:05:12.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c9/f9adeecbcdb53d05dd14817aff0ba70105349f3972b32abb28187f0d48d4/mfusepy-1.1.1-py3-none-any.whl", hash = "sha256:71b9245505bfe050c7c80c3b7c3a917211139c8fd8fabaacd43e9d4c529f822b", size = 23174, upload-time = "2025-07-07T21:05:11.903Z" },
+]
+
+[[package]]
+name = "mfusepy"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/47/746287c8962274f73ee25edb3840d80899464bfffbe2c435424c2d60a071/mfusepy-3.1.1.tar.gz", hash = "sha256:338ece54513d7d1a5e9492837679a0c7432ecf96a03490a2683a1ce1d19570e1", size = 34549, upload-time = "2026-03-13T00:36:52.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/d5/56bc9326bf75f7ea0f4fe1178f5c9f20d1a1e15e288ecf66088513538ccd/mfusepy-3.1.1-py3-none-any.whl", hash = "sha256:69fb70cfc7f7cce595e6ff586f8451d8298f01f18286a157f24f564b24ec5a37", size = 28264, upload-time = "2026-03-13T00:36:51.843Z" },
+]
 
 [[package]]
 name = "mtkclient"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
-    { name = "fusepy" },
+    { name = "mfusepy", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "mfusepy", version = "3.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pycryptodome" },
     { name = "pycryptodomex" },
     { name = "pyserial" },
@@ -42,7 +61,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "colorama" },
-    { name = "fusepy" },
+    { name = "mfusepy" },
     { name = "pycryptodome" },
     { name = "pycryptodomex" },
     { name = "pyserial" },


### PR DESCRIPTION
fusepy has not been updated in 8 years, as was fuse2 itself. mfusepy is a compatible implementation with support for fuse3.