### PR TITLE
Fix reading multiple partitions with read command

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -347,11 +347,13 @@ class DaHandler(metaclass=LogBase):
                             break
                     if rpartition is not None:
                         if length is None:
-                            length = rpartition.sectors * self.config.pagesize
+                            readlength = rpartition.sectors * self.config.pagesize
+                        else:
+                            readlength = length
                         if display:
                             self.info(f'Dumping partition "{rpartition.name}"')
                         if self.mtk.daloader.readflash(addr=(rpartition.sector * self.config.pagesize) + offset,
-                                                       length=length,
+                                                       length=readlength,
                                                        filename=partfilename, parttype=parttype, display=display):
                             if display:
                                 self.info(f"Dumped sector {str(rpartition.sector)} with sector count " +


### PR DESCRIPTION
When executing read command with multiple partitions like:

```
mtk r boot_a,cust boot_a.bin,cust.bin
```

All partitions were treated as they are the same length - length of the first partition on the list. After first loop iteration `length` variable was no longer `None`, so it wasn't updated with current partition length.