### PR TITLE
Fix MT6768 BROM USB handshake and interface selection (0e8d:0003)

### DIFF
--- a/mtkclient/Library/DA/mtk_da_handler.py
+++ b/mtkclient/Library/DA/mtk_da_handler.py
@@ -120,14 +120,15 @@ class DaHandler(metaclass=LogBase):
                 step = self.mtk.step
                 mtk.preloader.dump_internal_flash(offset=offset,length=length,step=step,filename="internal_flash.bin")
         else:
-            if mtk.serialportname is not None:
-                mtk.preloader.init()
             if directory:
                 self.mtk.config.hwparam_path = directory
             if mtk.port.cdc.connected and os.path.exists(os.path.join(mtk.config.hwparam_path, ".state")):
                 mtk.daloader.reinit()
                 mtk.reinited = True
                 return mtk
+            else:
+                # Device found via USB but no DA state — likely BROM mode already connected
+                mtk.preloader.init(directory=directory)
         if mtk.config.target_config is None:
             self.info("Please disconnect, start mtkclient and reconnect.")
             return None

--- a/mtkclient/Library/Port.py
+++ b/mtkclient/Library/Port.py
@@ -73,8 +73,8 @@ class Port(metaclass=LogBase):
             while i < length:
                 if ep_out(int.to_bytes(startcmd[i], 1, 'little')):
                     v = ep_in(1, timeout=20)  # Do not wait 1 sec, bootloader is only active for 0.3 sec.
-                    if len(v) == 1 and v[0] == ~(startcmd[i]) & 0xFF:
-                        i += 1
+                    if len(v) == 1 and (v[0] == ~(startcmd[i]) & 0xFF or v[0] == startcmd[i]):
+                        i += 1  # complement (UART) or same-byte echo (USB command mode)
                     else:
                         i = 0
             self.info("Device detected :)")
@@ -134,40 +134,43 @@ class Port(metaclass=LogBase):
         self.cdc.setcontrollinestate(rts=True)
 
         startcmd = b"\xa0\x0a\x50\x05"
-        expected_echo = bytes(~b & 0xFF for b in startcmd)  # Precompute: b'\x5f\xf5\xaf\xfa'
 
         brom_pids = [0x3, 0xF200, 0xD1E9, 0xD1E2, 0xD1EC, 0xD1DD]
         if self.cdc.pid not in brom_pids:
-            ep_out(b"\xa0")  # Send first byte separately if needed
+            ep_out(b"\xa0")
 
         for attempt in range(retries):
-            received = b""
             try:
+                # Flush any bytes BROM sent before we started
+                try:
+                    ep_in(maxinsize, timeout=50)
+                except Exception:
+                    pass
+
+                success = True
                 for byte in startcmd:
-                    written = ep_out(bytes([byte]), timeout=500)  # Explicit timeout
-                    if written != 1:
-                        raise ValueError("Write failed")
+                    ep_out(bytes([byte]), timeout=500)
+                    got_echo = False
+                    for _ in range(64):
+                        try:
+                            echo = ep_in(1, timeout=100)
+                            if len(echo) == 1:
+                                if echo[0] == (~byte & 0xFF) or echo[0] == byte:
+                                    got_echo = True  # complement (UART) or same-byte (USB)
+                                    break
+                        except Exception:
+                            break
+                    if not got_echo:
+                        success = False
+                        break
 
-                    # Read exactly 1 echo byte (fastest)
-                    echo = ep_in(1, timeout=500)
-                    if len(echo) != 1 or echo[0] != (~byte & 0xFF):
-                        raise ValueError(f"Echo mismatch: got {echo!r}, expected {~byte & 0xFF:02x}")
-
-                    received += echo
-
-                if received == expected_echo:
+                if success:
                     self.info("Device detected :)")
                     return True
 
-            except Exception as e:  # Includes USBError, timeout, pipe error
+            except Exception as e:
                 self.debug(f"Handshake attempt {attempt + 1} failed: {e}")
-                time.sleep(0.01)  # Short backoff
-
-            # Optional: flush input buffer before retry
-            try:
-                ep_in(maxinsize, timeout=50)  # Discard any stale data
-            except:
-                pass
+                time.sleep(0.01)
 
         self.info("Handshake failed after retries")
         return False

--- a/mtkclient/Library/exploit_handler.py
+++ b/mtkclient/Library/exploit_handler.py
@@ -94,7 +94,7 @@ class Exploitation(metaclass=LogBase):
                     return True
             except Exception as _exploit_ex:
                 self.error(f"Error on sending payload: {_exploit_ex}")
-                traceback.print_exc()
+                self.debug(traceback.format_exc())
                 return False
         else:
             self.info("Sending payload via insecure da.")

--- a/mtkclient/Library/exploit_handler.py
+++ b/mtkclient/Library/exploit_handler.py
@@ -3,6 +3,7 @@
 # (c) B.Kerler 2018-2025 GPLv3 License
 import logging
 import time
+import traceback
 from struct import pack, unpack
 
 from mtkclient.Library.Hardware.hwcrypto import HwCrypto, CryptoSetup
@@ -91,8 +92,9 @@ class Exploitation(metaclass=LogBase):
                     self.info("Done sending payload...")
                     time.sleep(0.2)
                     return True
-            except Exception:
-                self.error("Error on sending payload.")
+            except Exception as _exploit_ex:
+                self.error(f"Error on sending payload: {_exploit_ex}")
+                traceback.print_exc()
                 return False
         else:
             self.info("Sending payload via insecure da.")

--- a/mtkclient/config/usb_ids.py
+++ b/mtkclient/config/usb_ids.py
@@ -1,5 +1,5 @@
 default_ids = {
-    0x0E8D: {0x0003: -1,  # MTK Brom
+    0x0E8D: {0x0003: 1,  # MTK Brom - interface 1 has bulk endpoints (interface 0 is CDC comm/control only)
              0x6000: 2,  # MTK Preloader
              0x2000: -1,  # MTK Preloader
              0x2001: -1,  # MTK Preloader


### PR DESCRIPTION
## Summary
Fixes BROM communication for MediaTek MT6768 (Helio P65/G85) over USB CDC when the device enumerates as `0e8d:0003`.

## Problems fixed
1. **usb_ids.py** — PID `0x0003` used interface `-1` (auto); auto-select picked CDC comm interface 0 (interrupt only, no bulk). Bulk endpoints are on interface 1.
2. **Port.py** — BROM handshake only accepted bitwise-complement echo (UART). MT6768 BROM over USB echoes the same byte; handshake looped forever (`Handshake failed, retrying...`).
3. **mtk_da_handler.py** — If the device was already connected in USB BROM mode at startup, `preloader.init()` was skipped → `Please disconnect, start mtkclient and reconnect.`
4. **exploit_handler.py** — Payload failures were caught without logging the underlying exception (hid `AttributeError` when `--serialport` was used).

## Test device
- **Model:** Lenovo Tab M9 TB310XU
- **SoC:** MT6768 / MT6769, HW code `0x707`
- **Host:** Ubuntu Linux, udev rules from `Setup/Linux/`, ModemManager masked
- **Command:** `sudo python3 mtk.py e frp`
- **Result:** FRP partition formatted at `0x1508000`, device boots to setup wizard without account lock

## Notes
- Debugged with AI assistance; reproduced on physical hardware.
- Does not use `--serialport` (Kamakiri2 requires USB `ctrl_transfer`).
- macOS host may still have separate libusb permission issues; this PR targets Linux USB path.

## Checklist
- [x] Tested on real MT6768 hardware
- [x] Minimal diff, no unrelated changes