### PR TITLE
Fix USB protocol desync after failed DA XML extension loading

### DIFF
--- a/mtkclient/Library/DA/xmlflash/xml_lib.py
+++ b/mtkclient/Library/DA/xmlflash/xml_lib.py
@@ -740,6 +740,21 @@ class DAXML(metaclass=LogBase):
                     else:
                         self.error("DA XML Extensions failed.")
                         self.daext = False
+                        # Drain any residual protocol messages (CMD:END → ACK → CMD:START)
+                        # to prevent USB desync with the next command. When DA responds with
+                        # ERR!UNSUPPORTED (e.g. custom DA without extension support), the
+                        # follow-up protocol sequence must be consumed, otherwise leftover
+                        # frames corrupt the next xread() call (e.g. GPT read).
+                        if "ERR" in str(data):
+                            try:
+                                scmd, _ = self.get_command_result()
+                                if scmd == "CMD:END":
+                                    self.ack()
+                                    tcmd, _ = self.get_command_result()
+                                    if tcmd == "CMD:START":
+                                        pass
+                            except Exception:
+                                pass
                 # parttbl = self.read_partition_table()
                 self.config.hwparam.writesetting("hwcode", hex(self.config.hwcode))
                 return True


### PR DESCRIPTION
When the CUSTOM command is unrecognized by the DA (e.g. custom DA without extension support), the DA responds with ERR!UNSUPPORTED followed by CMD:END and CMD:START protocol messages. The extension loading code only consumed the first response, leaving CMD:END and CMD:START pending in the USB buffer. 

This desynchronized the protocol: subsequent xread() calls (e.g. during GPT read via printgpt) would read stale protocol frames instead of the expected response header, causing 'xread: Wrong length' and GPT read failure. 

Fix by draining the residual CMD:END -> ACK -> CMD:START sequence after the extension loading failure, matching the standard ERR!UNSUPPORTED handling pattern in send_command().