### PR TITLE
Fix RPMB result codes being silently discarded

### DIFF
--- a/mtkclient/Library/DA/xflash/extension/xflash.py
+++ b/mtkclient/Library/DA/xflash/extension/xflash.py
@@ -45,6 +45,14 @@ rpmb_error = [
 ]
 
 
+def rpmb_error_msg(resp: int) -> str:
+    """Maps an RPMB result code to its message. Codes outside the JEDEC set are
+    reported as-is instead of being silently dropped."""
+    if 0 < resp < len(rpmb_error):
+        return rpmb_error[resp]
+    return f"Unknown RPMB error: {hex(resp)}"
+
+
 class XFlashExt(metaclass=LogBase):
     def __init__(self, mtk, xflash, loglevel):
         self.lasterror = None
@@ -477,10 +485,7 @@ class XFlashExt(metaclass=LogBase):
                 tmp = self.xread()
                 if len(tmp) != 0x100:
                     resp = int.from_bytes(tmp, 'little')
-                    if resp in rpmb_error:
-                        msg = rpmb_error[resp]
-                    else:
-                        msg = f"Error: {hex(resp)}"
+                    msg = rpmb_error_msg(resp)
                     self.error(f"Error on sector {hex(sector)}: {msg})")
                     return b""
                 else:
@@ -503,10 +508,9 @@ class XFlashExt(metaclass=LogBase):
                 self.xsend(data[i * 0x100:(i * 0x100) + 0x100])
                 resp = unpack("<H", self.xread())[0]
                 if resp != 0:
-                    if resp in rpmb_error:
-                        self.error(rpmb_error[resp])
-                        status = self.status()
-                        return False
+                    self.error(f"Error on sector {hex(sector + i)}: {rpmb_error_msg(resp)}")
+                    self.status()
+                    return False
             status = self.status()
             if status == 0:
                 return True

--- a/mtkclient/Library/DA/xmlflash/extension/v6.py
+++ b/mtkclient/Library/DA/xmlflash/extension/v6.py
@@ -35,6 +35,15 @@ rpmb_error = [
     "Authentication key not yet programmed"
 ]
 
+
+def rpmb_error_msg(resp: int) -> str:
+    """Maps an RPMB result code to its message. Codes outside the JEDEC set are
+    reported as-is instead of being silently dropped."""
+    if 0 < resp < len(rpmb_error):
+        return rpmb_error[resp]
+    return f"Unknown RPMB error: {hex(resp)}"
+
+
 RET_32_R0 = b"\x00\x00\xA0\xE3\x1E\xFF\x2F\xE1"
 
 class XmlFlashExt(metaclass=LogBase):
@@ -626,10 +635,7 @@ class XmlFlashExt(metaclass=LogBase):
                     tmp = self.xflash.get_response(raw=True)
                     if len(tmp) != 0x100:
                         resp = int.from_bytes(tmp, 'little')
-                        if resp in rpmb_error:
-                            msg = rpmb_error[resp]
-                        else:
-                            msg = f"Error: {hex(resp)}"
+                        msg = rpmb_error_msg(resp)
                         self.error(f"Error on sector {hex(sector)}: {msg})")
                         return b""
                     else:
@@ -656,8 +662,7 @@ class XmlFlashExt(metaclass=LogBase):
                     self.xsend(data[i * 0x100:(i * 0x100) + 0x100])
                     resp = unpack("<H", self.xflash.get_response(raw=True))[0]
                     if resp != 0:
-                        if resp in rpmb_error:
-                            self.error(rpmb_error[resp])
+                        self.error(f"Error on sector {hex(sector + i)}: {rpmb_error_msg(resp)}")
                         result = self.xflash.get_response()
                         self.xflash.ack()
                         # CMD:START


### PR DESCRIPTION
`rpmb_error` is a list of strings, but both backends test result codes against it with `in`:

```python
resp = unpack("<H", self.xread())[0]
if resp != 0:
    if resp in rpmb_error:
        self.error(rpmb_error[resp])
        status = self.status()
        return False
```

`resp` is an integer and the list holds strings, so `resp in rpmb_error` is a value membership test rather than an index, and it is false for every possible result code:

```
>>> 2 in ["", "General failure", "Authentication failure", ...]
False
>>> 4 in ["", "General failure", "Authentication failure", ...]
False
```

The intent was clearly `rpmb_error[resp]`.

### Why it matters more in xflash than in xmlflash

In `xflash/extension/xflash.py` the `return False` sits **inside** that dead branch. A rejected frame therefore falls through the loop, reaches `status = self.status()`, and the function returns `True`. A write the controller refused is reported as successful, and nothing is printed at all.

In `xmlflash/extension/v6.py` the `return False` sits **outside** the branch, so the failure is still propagated correctly there and only the message is lost.

That difference explains why this shows up as "the write reports success but the data is unchanged" on xflash targets specifically.

### Observed case

Issue #305 reports RPMB erase and write completing successfully on a MT6877 device with SK Hynix UFS while a re-dump shows the region byte-for-byte unchanged. With this code path, whatever result code that controller returned was discarded before it could be printed, so the actual reason for the rejection is currently unobservable from the log. There is a second independent report of the same symptom on the same SoC outside this tracker.

This patch does not change whether such a write succeeds. It makes the controller's answer visible, which is a prerequisite for diagnosing it.

### Change

Adds a small helper next to the table in both backends:

```python
def rpmb_error_msg(resp: int) -> str:
    if 0 < resp < len(rpmb_error):
        return rpmb_error[resp]
    return f"Unknown RPMB error: {hex(resp)}"
```

and uses it at the four call sites. Codes inside the JEDEC set are named, codes outside it are printed as hex rather than dropped, which also covers the write-counter-expired bit that the current table does not describe. The dead `if` around the write path's `return False` is removed so a non-zero result always aborts the write.

The read paths already had an `else` fallback and behaved sanely. They are routed through the same helper for consistency.

Both files compile and the helper is behaviour-checked for codes 0x1 to 0x7, 0x80 and 0xFFFF. The table itself is duplicated across the two backends in the current tree, so the helper is duplicated with it rather than introducing a shared module. Happy to factor both out if you would rather have that.
